### PR TITLE
Add .NET 5 and Swagger

### DIFF
--- a/KristinsKitchen/KristinsKitchen.csproj
+++ b/KristinsKitchen/KristinsKitchen.csproj
@@ -1,8 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.0" />
+  </ItemGroup>
 
 
 </Project>

--- a/KristinsKitchen/Startup.cs
+++ b/KristinsKitchen/Startup.cs
@@ -26,6 +26,8 @@ namespace KristinsKitchen
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllers();
+            // Register the Swagger generator, defining 1 or more Swagger documents
+            services.AddSwaggerGen();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -37,6 +39,16 @@ namespace KristinsKitchen
             }
 
             app.UseHttpsRedirection();
+
+            // Enable middleware to serve generated Swagger as a JSON endpoint.
+            app.UseSwagger();
+
+            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.),
+            // specifying the Swagger JSON endpoint.
+            app.UseSwaggerUI(c =>
+            {
+                c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
+            });
 
             app.UseRouting();
 


### PR DESCRIPTION
Initialization steps to refactor from .NET 3.1 to .NET 5.0. Added Swagger services and UI endpoint for API reference.

Swagger is accessible at `<root>/swagger`.